### PR TITLE
Share websocket manager singleton across API surfaces

### DIFF
--- a/backend/app/api/websockets.py
+++ b/backend/app/api/websockets.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 import json
-from ..services.websocket_manager import WebSocketManager
+from ..services.websocket_manager import get_websocket_manager
 
 router = APIRouter()
 
-# Global WebSocket manager instance
-websocket_manager = WebSocketManager()
+# Global WebSocket manager instance shared across the application
+websocket_manager = get_websocket_manager()
 
 @router.websocket("/conversation/{conversation_id}")
 async def websocket_endpoint(websocket: WebSocket, conversation_id: str):

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,4 +1,12 @@
 from .conversation_orchestrator import ConversationOrchestrator
 from .persona_manager import PersonaManager
 from .turn_manager import TurnManager
-from .websocket_manager import WebSocketManager
+from .websocket_manager import WebSocketManager, get_websocket_manager
+
+__all__ = [
+    "ConversationOrchestrator",
+    "PersonaManager",
+    "TurnManager",
+    "WebSocketManager",
+    "get_websocket_manager",
+]

--- a/backend/app/services/conversation_orchestrator.py
+++ b/backend/app/services/conversation_orchestrator.py
@@ -10,13 +10,13 @@ from ..providers import OpenAIProvider, ClaudeProvider, DeepSeekProvider, Gemini
 from ..core.config import settings
 from .persona_manager import PersonaManager
 from .turn_manager import TurnManager
-from .websocket_manager import WebSocketManager
+from .websocket_manager import WebSocketManager, get_websocket_manager
 
 class ConversationOrchestrator:
-    def __init__(self):
+    def __init__(self, websocket_manager: Optional[WebSocketManager] = None):
         self.persona_manager = PersonaManager()
         self.turn_manager = TurnManager()
-        self.websocket_manager = WebSocketManager()
+        self.websocket_manager = websocket_manager or get_websocket_manager()
         self.providers = self._initialize_providers()
 
     def _initialize_providers(self) -> Dict[str, Any]:

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 from fastapi import WebSocket
 from ..core.redis_client import redis_client
 
@@ -82,3 +82,19 @@ class WebSocketManager:
         }
 
         await self.broadcast_to_conversation(conversation_id, status_message)
+
+
+# Singleton accessor -------------------------------------------------------
+
+_websocket_manager_singleton: Optional[WebSocketManager] = None
+
+
+def get_websocket_manager() -> WebSocketManager:
+    """Return the process-wide WebSocket manager instance."""
+
+    global _websocket_manager_singleton
+
+    if _websocket_manager_singleton is None:
+        _websocket_manager_singleton = WebSocketManager()
+
+    return _websocket_manager_singleton

--- a/docs/current_state_todo.md
+++ b/docs/current_state_todo.md
@@ -11,7 +11,7 @@ This document maps the present capabilities of the Chimera MVP against the remai
 - Persona and turn managers hold in-memory state that selects weighted speakers, emits typing indicators, and simulates natural delays.
 
 ### TODO
-- [ ] Share a single WebSocket manager instance between the orchestrator and `/ws` router so UI listeners receive streamed turns.
+- [x] Share a single WebSocket manager instance between the orchestrator and `/ws` router so UI listeners receive streamed turns. _(2025-09-25)_
 - [ ] Replace the stubbed conversation history helper with persisted message retrieval.
 - [ ] Implement database writes inside `_save_and_broadcast_message` using SQLAlchemy sessions.
 - [ ] Add proper error logging/observability around provider failures and orchestration loops.
@@ -75,6 +75,6 @@ This document maps the present capabilities of the Chimera MVP against the remai
 
 ## Immediate Next Steps
 - [ ] Wire database persistence (history retrieval + writes) so the orchestrator and REST API operate on real data.
-- [ ] Unify WebSocket broadcasting to deliver conversation events to clients.
+- [x] Unify WebSocket broadcasting to deliver conversation events to clients. _(2025-09-25)_
 - [ ] Produce the first Alembic migration and run it inside Docker Compose to validate the data layer.
 - [ ] Draft smoke tests that exercise REST + WebSocket flows end-to-end using mock providers.


### PR DESCRIPTION
## Summary
- expose a singleton `WebSocketManager` accessor and reuse it inside the orchestrator and websocket router
- allow `ConversationOrchestrator` to accept an injected manager for easier testing and reuse
- document the completed websocket broadcasting milestone in the current state tracker

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68d5ae31118883248547f8dfd6283a27