### PR TITLE
Add Alembic revision and database smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Chimera Multi-AI Chat - Development Commands
 
-.PHONY: help dev dev-db dev-backend dev-frontend build up down clean logs test migrate
+.PHONY: help dev dev-db dev-backend dev-frontend build up down clean logs test migrate db-upgrade
 
 help:
 	@echo "Chimera Multi-AI Chat Development Commands"
@@ -11,15 +11,16 @@ help:
 	@echo "  dev-backend  - Start backend development server"
 	@echo "  dev-frontend - Start frontend development server"
 	@echo ""
-	@echo "Production:"
-	@echo "  build        - Build all Docker images"
-	@echo "  up           - Start production environment"
-	@echo "  down         - Stop all services"
-	@echo ""
-	@echo "Database:"
-	@echo "  migrate      - Run database migrations"
-	@echo "  migrate-auto - Generate and run auto-migration"
-	@echo ""
+        @echo "Production:"
+        @echo "  build        - Build all Docker images"
+        @echo "  up           - Start production environment"
+        @echo "  down         - Stop all services"
+        @echo ""
+        @echo "Database:"
+        @echo "  db-upgrade   - Apply Alembic migrations (alembic upgrade head)"
+        @echo "  migrate      - Run database migrations"
+        @echo "  migrate-auto - Generate and run auto-migration"
+        @echo ""
 	@echo "Utilities:"
 	@echo "  logs         - Show logs from all services"
 	@echo "  clean        - Clean up Docker volumes and images"
@@ -62,8 +63,11 @@ down:
 	docker compose -f docker-compose.dev.yml down
 
 # Database commands
+db-upgrade:
+        cd backend && . venv/bin/activate && alembic -c alembic.ini upgrade head
+
 migrate:
-	cd backend && . venv/bin/activate && alembic upgrade head
+        cd backend && . venv/bin/activate && alembic upgrade head
 
 migrate-auto:
 	cd backend && . venv/bin/activate && alembic revision --autogenerate -m "Auto migration"

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,26 @@
+# Backend setup and migrations
+
+This backend uses Alembic to manage the SQLAlchemy models. To align a local database with the current `User`, `Conversation`, and `Message` schemas:
+
+1. Create and activate a virtual environment inside `backend/`:
+   ```bash
+   cd backend
+   python -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Point `DATABASE_URL` to your target database (defaults to `sqlite:///./chimera.db`).
+3. Apply migrations with the repo-level helper:
+   ```bash
+   make db-upgrade
+   ```
+   The target runs `alembic -c alembic.ini upgrade head` against the configured database.
+
+For manual runs, you can also execute Alembic directly:
+```bash
+cd backend
+source venv/bin/activate
+alembic -c alembic.ini upgrade head
+```
+
+After running migrations, the database will include the latest columns for authentication, conversation sharing, and message metadata alignment. A lightweight smoke test is available via `python -m pytest tests/test_db_connectivity.py` to verify connectivity.

--- a/backend/alembic/versions/b31e9e8b17cf_align_core_models_with_schema.py
+++ b/backend/alembic/versions/b31e9e8b17cf_align_core_models_with_schema.py
@@ -1,0 +1,60 @@
+# backend/alembic/versions/b31e9e8b17cf_align_core_models_with_schema.py
+"""Align core models with schema
+
+Revision ID: b31e9e8b17cf
+Revises: 1f4b5209bee4
+Create Date: 2025-10-08 20:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b31e9e8b17cf"
+down_revision: Union[str, None] = "1f4b5209bee4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema to match current core models."""
+    # Add missing authentication field to users
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(sa.Column("hashed_password", sa.Text(), nullable=True))
+
+    # Add sharing controls to conversations
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.add_column(
+            sa.Column("is_public", sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+        batch_op.add_column(sa.Column("share_token", sa.String(length=255), nullable=True))
+
+    # Align message metadata naming with the model
+    with op.batch_alter_table("messages") as batch_op:
+        batch_op.alter_column(
+            "message_metadata",
+            new_column_name="metadata",
+            existing_type=sa.JSON(),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    """Revert schema changes for core models."""
+    with op.batch_alter_table("messages") as batch_op:
+        batch_op.alter_column(
+            "metadata",
+            new_column_name="message_metadata",
+            existing_type=sa.JSON(),
+            existing_nullable=True,
+        )
+
+    with op.batch_alter_table("conversations") as batch_op:
+        batch_op.drop_column("share_token")
+        batch_op.drop_column("is_public")
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("hashed_password")

--- a/backend/tests/test_db_connectivity.py
+++ b/backend/tests/test_db_connectivity.py
@@ -1,0 +1,57 @@
+# backend/tests/test_db_connectivity.py
+"""Lightweight database connectivity smoke test."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.database import Base
+from app.models.user import User
+
+
+def test_sessionlocal_crud_roundtrip() -> None:
+    """Verify CRUD operations against a temporary in-memory database."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    # Prepare schema for the isolated database.
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+
+    try:
+        # Create
+        user = User(
+            username="smoke-user",
+            email="smoke@example.com",
+            hashed_password="secret",
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        assert user.id
+
+        # Read
+        fetched_user = session.query(User).filter_by(id=user.id).one()
+        assert fetched_user.username == "smoke-user"
+
+        # Update
+        fetched_user.username = "updated-user"
+        session.commit()
+        session.refresh(fetched_user)
+        assert (
+            session.query(User.username).filter_by(id=user.id).scalar() == "updated-user"
+        )
+
+        # Delete
+        session.delete(fetched_user)
+        session.commit()
+        assert session.query(User).count() == 0
+    finally:
+        # Clean up resources to avoid cross-test contamination.
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()


### PR DESCRIPTION
## Summary
- add an Alembic revision that aligns user, conversation, and message tables with the current models
- provide a db-upgrade make target and backend documentation for running migrations
- add a database connectivity smoke test covering CRUD against a temporary SessionLocal

## Testing
- python -m pytest tests/test_db_connectivity.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ef93114483249b15c119ce32298e)