### PR TITLE
Improve websocket error handling and heartbeat tests

### DIFF
--- a/backend/app/api/websockets.py
+++ b/backend/app/api/websockets.py
@@ -1,11 +1,19 @@
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+# websockets.py
+"""WebSocket API router for conversation events."""
+
 import json
+import logging
+import time
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
 from ..services.websocket_manager import get_websocket_manager
 
 router = APIRouter()
 
 # Global WebSocket manager instance shared across the application
 websocket_manager = get_websocket_manager()
+logger = logging.getLogger(__name__)
 
 @router.websocket("/conversation/{conversation_id}")
 async def websocket_endpoint(websocket: WebSocket, conversation_id: str):
@@ -19,9 +27,9 @@ async def websocket_endpoint(websocket: WebSocket, conversation_id: str):
                 "type": "connection",
                 "status": "connected",
                 "conversation_id": conversation_id,
-                "timestamp": __import__('time').time()
+                "timestamp": time.time(),
             },
-            websocket
+            websocket,
         )
 
         # Send current conversation status
@@ -30,26 +38,35 @@ async def websocket_endpoint(websocket: WebSocket, conversation_id: str):
         # Listen for client messages
         while True:
             data = await websocket.receive_text()
+            websocket_manager.mark_heartbeat(conversation_id, websocket)
 
             try:
                 message = json.loads(data)
                 await handle_websocket_message(websocket, conversation_id, message)
             except json.JSONDecodeError:
-                await websocket_manager.send_personal_message(
-                    {
-                        "type": "error",
-                        "message": "Invalid JSON format"
-                    },
-                    websocket
+                await websocket_manager.send_error(
+                    websocket,
+                    code="invalid_json",
+                    message="Invalid JSON payload; expected JSON text.",
                 )
 
-    except WebSocketDisconnect:
-        websocket_manager.disconnect(websocket, conversation_id)
+    except WebSocketDisconnect as exc:
+        websocket_manager.disconnect(
+            websocket, conversation_id, reason="client_disconnect", detail=str(exc)
+        )
         await websocket_manager.send_conversation_status(conversation_id)
 
     except Exception as e:
-        print(f"WebSocket error: {e}")
-        websocket_manager.disconnect(websocket, conversation_id)
+        logger.exception("WebSocket error", extra={"conversation_id": conversation_id})
+        await websocket_manager.send_error(
+            websocket,
+            code="internal_error",
+            message="An internal server error occurred.",
+        )
+        websocket_manager.disconnect(
+            websocket, conversation_id, reason="server_error", detail=str(e)
+        )
+        await websocket_manager.send_conversation_status(conversation_id)
 
 async def handle_websocket_message(websocket: WebSocket, conversation_id: str, message: dict):
     """Handle incoming WebSocket messages from clients"""
@@ -60,21 +77,22 @@ async def handle_websocket_message(websocket: WebSocket, conversation_id: str, m
         await websocket_manager.send_personal_message(
             {
                 "type": "pong",
-                "timestamp": __import__('time').time()
+                "timestamp": time.time(),
             },
-            websocket
+            websocket,
         )
+        websocket_manager.mark_heartbeat(conversation_id, websocket)
 
     elif message_type == "user_message":
         # Handle user messages (broadcast to other clients)
         user_message = {
             "type": "message",
-            "id": f"user_msg_{__import__('time').time()}",
+            "id": f"user_msg_{time.time()}",
             "conversation_id": conversation_id,
             "sender_type": "user",
             "sender_id": message.get("user_id", "anonymous"),
             "content": message.get("content", ""),
-            "timestamp": __import__('time').time()
+            "timestamp": time.time(),
         }
 
         await websocket_manager.broadcast_to_conversation(conversation_id, user_message)
@@ -83,12 +101,25 @@ async def handle_websocket_message(websocket: WebSocket, conversation_id: str, m
         # Send current conversation status
         await websocket_manager.send_conversation_status(conversation_id)
 
-    else:
-        # Unknown message type
+    elif message_type == "disconnect":
+        # Client requested disconnect
+        reason = message.get("reason", "client_requested")
         await websocket_manager.send_personal_message(
             {
-                "type": "error",
-                "message": f"Unknown message type: {message_type}"
+                "type": "disconnect",
+                "reason": reason,
+                "timestamp": time.time(),
             },
-            websocket
+            websocket,
+        )
+        await websocket.close(code=1000)
+        websocket_manager.disconnect(websocket, conversation_id, reason=reason)
+        await websocket_manager.send_conversation_status(conversation_id)
+
+    else:
+        # Unknown message type
+        await websocket_manager.send_error(
+            websocket,
+            code="unknown_message",
+            message=f"Unknown message type: {message_type}",
         )

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -1,37 +1,83 @@
+# websocket_manager.py
+"""WebSocket manager providing connection lifecycle and broadcasting."""
+
+import asyncio
 import json
-from typing import Dict, List, Optional, Set
+import logging
+import time
+from typing import Dict, Optional
+
 from fastapi import WebSocket
+
 from ..core.redis_client import redis_client
 
+
 class WebSocketManager:
-    def __init__(self):
-        # Store active connections per conversation
-        self.active_connections: Dict[str, Set[WebSocket]] = {}
+    def __init__(
+        self,
+        heartbeat_interval: float = 15.0,
+        connection_timeout: float = 45.0,
+    ):
+        # Store active connections per conversation with last heartbeat timestamps
+        self.active_connections: Dict[str, Dict[WebSocket, float]] = {}
+        self.heartbeat_interval = heartbeat_interval
+        self.connection_timeout = connection_timeout
+        self._heartbeat_task: Optional[asyncio.Task] = None
+        self.logger = logging.getLogger(__name__)
 
     async def connect(self, websocket: WebSocket, conversation_id: str):
         """Connect a websocket to a conversation"""
         await websocket.accept()
 
         if conversation_id not in self.active_connections:
-            self.active_connections[conversation_id] = set()
+            self.active_connections[conversation_id] = {}
 
-        self.active_connections[conversation_id].add(websocket)
+        self.active_connections[conversation_id][websocket] = time.time()
+        self._ensure_heartbeat_task()
+        self.logger.info(
+            "WebSocket connected", extra={"conversation_id": conversation_id}
+        )
 
-    def disconnect(self, websocket: WebSocket, conversation_id: str):
+    def disconnect(
+        self,
+        websocket: WebSocket,
+        conversation_id: str,
+        *,
+        reason: str = "disconnect",
+        detail: Optional[str] = None,
+    ):
         """Disconnect a websocket from a conversation"""
         if conversation_id in self.active_connections:
-            self.active_connections[conversation_id].discard(websocket)
+            self.active_connections[conversation_id].pop(websocket, None)
 
             # Clean up empty conversation rooms
             if not self.active_connections[conversation_id]:
                 del self.active_connections[conversation_id]
 
+        self.logger.info(
+            "WebSocket disconnected",
+            extra={
+                "conversation_id": conversation_id,
+                "reason": reason,
+                "detail": detail,
+            },
+        )
+
     async def send_personal_message(self, message: dict, websocket: WebSocket):
         """Send a message to a specific websocket connection"""
         try:
             await websocket.send_text(json.dumps(message))
-        except Exception as e:
-            print(f"Error sending personal message: {e}")
+        except Exception:
+            self.logger.exception(
+                "Error sending personal message", extra={"payload": message}
+            )
+
+    async def send_error(self, websocket: WebSocket, *, code: str, message: str):
+        """Send a structured error payload to the client."""
+        await self.send_personal_message(
+            {"type": "error", "code": code, "message": message, "timestamp": time.time()},
+            websocket,
+        )
 
     async def broadcast_to_conversation(self, conversation_id: str, message: dict):
         """Broadcast a message to all clients in a conversation"""
@@ -39,20 +85,24 @@ class WebSocketManager:
             return
 
         # Create a copy of the set to avoid modification during iteration
-        connections = self.active_connections[conversation_id].copy()
+        connections = list(self.active_connections[conversation_id].keys())
 
         disconnected_connections = []
 
         for connection in connections:
             try:
                 await connection.send_text(json.dumps(message))
-            except Exception as e:
-                print(f"Error broadcasting to connection: {e}")
+                self.mark_heartbeat(conversation_id, connection)
+            except Exception:
+                self.logger.exception(
+                    "Error broadcasting to connection",
+                    extra={"conversation_id": conversation_id},
+                )
                 disconnected_connections.append(connection)
 
         # Clean up disconnected connections
         for connection in disconnected_connections:
-            self.disconnect(connection, conversation_id)
+            self.disconnect(connection, conversation_id, reason="broadcast_error")
 
         # Also publish to Redis for scaling across multiple instances
         await self._publish_to_redis(conversation_id, message)
@@ -61,15 +111,16 @@ class WebSocketManager:
         """Publish message to Redis for cross-instance communication"""
         try:
             await redis_client.publish(
-                f"conversation:{conversation_id}",
-                json.dumps(message)
+                f"conversation:{conversation_id}", json.dumps(message)
             )
-        except Exception as e:
-            print(f"Error publishing to Redis: {e}")
+        except Exception:
+            self.logger.exception(
+                "Error publishing to Redis", extra={"conversation_id": conversation_id}
+            )
 
     async def get_conversation_clients_count(self, conversation_id: str) -> int:
         """Get the number of active clients in a conversation"""
-        return len(self.active_connections.get(conversation_id, set()))
+        return len(self.active_connections.get(conversation_id, {}))
 
     async def send_conversation_status(self, conversation_id: str):
         """Send conversation status to all clients"""
@@ -78,10 +129,50 @@ class WebSocketManager:
             "type": "status",
             "conversation_id": conversation_id,
             "connected_clients": client_count,
-            "timestamp": __import__('time').time()
+            "timestamp": time.time(),
         }
 
         await self.broadcast_to_conversation(conversation_id, status_message)
+
+    def mark_heartbeat(self, conversation_id: str, websocket: WebSocket):
+        """Update the last seen timestamp for a websocket."""
+        if conversation_id in self.active_connections:
+            if websocket in self.active_connections[conversation_id]:
+                self.active_connections[conversation_id][websocket] = time.time()
+
+    async def remove_stale_connections(self):
+        """Remove connections that have not sent heartbeats within the timeout."""
+        now = time.time()
+        stale_connections = []
+
+        for conversation_id, connections in list(self.active_connections.items()):
+            for websocket, last_seen in list(connections.items()):
+                if now - last_seen > self.connection_timeout:
+                    stale_connections.append((conversation_id, websocket))
+
+        for conversation_id, websocket in stale_connections:
+            await self.send_error(
+                websocket,
+                code="heartbeat_timeout",
+                message="Connection closed due to inactivity.",
+            )
+            await websocket.close(code=1001)
+            self.disconnect(
+                websocket,
+                conversation_id,
+                reason="heartbeat_timeout",
+            )
+            await self.send_conversation_status(conversation_id)
+
+    def _ensure_heartbeat_task(self):
+        """Start the heartbeat monitoring task if needed."""
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    async def _heartbeat_loop(self):
+        while True:
+            await asyncio.sleep(self.heartbeat_interval)
+            await self.remove_stale_connections()
 
 
 # Singleton accessor -------------------------------------------------------

--- a/backend/tests/test_websocket_manager.py
+++ b/backend/tests/test_websocket_manager.py
@@ -1,5 +1,11 @@
+# test_websocket_manager.py
+"""Tests for WebSocketManager core behaviors."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
 import pytest
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+
 from app.services.websocket_manager import WebSocketManager
 
 @pytest.fixture
@@ -10,25 +16,43 @@ def ws_manager():
 async def test_connect_and_disconnect(ws_manager):
     mock_ws = AsyncMock()
     conversation_id = "test_conv"
-    
+
     await ws_manager.connect(mock_ws, conversation_id)
     assert conversation_id in ws_manager.active_connections
     assert mock_ws in ws_manager.active_connections[conversation_id]
-    
-    ws_manager.disconnect(mock_ws, conversation_id)
-    assert conversation_id not in ws_manager.active_connections or mock_ws not in ws_manager.active_connections[conversation_id]
+
+    ws_manager.disconnect(mock_ws, conversation_id, reason="test")
+    assert conversation_id not in ws_manager.active_connections
+
 
 @pytest.mark.asyncio
 async def test_broadcast_to_room(ws_manager):
     mock_ws1 = AsyncMock()
     mock_ws2 = AsyncMock()
     conversation_id = "test_conv"
-    
+
     await ws_manager.connect(mock_ws1, conversation_id)
     await ws_manager.connect(mock_ws2, conversation_id)
-    
+
     message = {"type": "test", "content": "Hello"}
     await ws_manager.broadcast_to_conversation(conversation_id, message)
-    
-    mock_ws1.send_json.assert_called_once_with(message)
-    mock_ws2.send_json.assert_called_once_with(message)
+
+    assert mock_ws1.send_text.await_count == 1
+    assert mock_ws2.send_text.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_connection_cleanup(ws_manager):
+    conversation_id = "stale_conv"
+    mock_ws = AsyncMock()
+    await ws_manager.connect(mock_ws, conversation_id)
+
+    # simulate stale by rewinding timestamp
+    ws_manager.active_connections[conversation_id][mock_ws] -= (
+        ws_manager.connection_timeout + 1
+    )
+
+    await ws_manager.remove_stale_connections()
+
+    assert conversation_id not in ws_manager.active_connections
+    assert mock_ws.close.await_count == 1

--- a/backend/tests/test_websockets.py
+++ b/backend/tests/test_websockets.py
@@ -1,0 +1,137 @@
+# test_websockets.py
+"""End-to-end websocket API tests using WebSocketTestSession."""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.api import websockets as ws_router
+from app.core.redis_client import redis_client
+
+
+class DummyRedis:
+    """Lightweight Redis stand-in for websocket tests."""
+
+    def __init__(self):
+        self.published: list[tuple[str, str]] = []
+
+    async def publish(self, channel: str, message: str) -> None:
+        self.published.append((channel, message))
+
+    async def close(self) -> None:  # pragma: no cover - graceful shutdown helper
+        return None
+
+
+@pytest.fixture()
+def anyio_backend():
+    """Force anyio to use asyncio backend to avoid optional trio dependency."""
+
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def reset_websocket_manager(monkeypatch):
+    """Reset connection state and stub Redis before each test."""
+
+    dummy_redis = DummyRedis()
+    monkeypatch.setattr("app.core.redis_client.redis.from_url", lambda *a, **k: dummy_redis)
+    redis_client.redis = dummy_redis
+
+    ws_router.websocket_manager.active_connections.clear()
+    ws_router.websocket_manager.connection_timeout = 0.2
+    ws_router.websocket_manager.heartbeat_interval = 0.05
+
+    if ws_router.websocket_manager._heartbeat_task and not ws_router.websocket_manager._heartbeat_task.done():
+        ws_router.websocket_manager._heartbeat_task.cancel()
+        try:
+            await ws_router.websocket_manager._heartbeat_task
+        except asyncio.CancelledError:
+            pass
+    ws_router.websocket_manager._heartbeat_task = None
+
+    yield
+
+    ws_router.websocket_manager.active_connections.clear()
+
+
+@pytest.fixture()
+def websocket_client():
+    """Create a minimal FastAPI instance that supports WebSocket connections."""
+
+    app_instance = FastAPI()
+    app_instance.include_router(ws_router.router, prefix="/ws")
+
+    with TestClient(app_instance) as client:
+        yield client
+
+
+@pytest.mark.anyio("asyncio")
+async def test_websocket_connect_and_status(websocket_client: TestClient):
+    with websocket_client.websocket_connect("/ws/conversation/conv-1") as session:
+        first = session.receive_json()
+        status = session.receive_json()
+
+    assert first["type"] == "connection"
+    assert status["type"] == "status"
+    assert status["connected_clients"] >= 0
+
+
+@pytest.mark.anyio("asyncio")
+async def test_invalid_json_handling(websocket_client: TestClient):
+    with websocket_client.websocket_connect("/ws/conversation/conv-2") as session:
+        session.receive_json()
+        session.receive_json()
+
+        session.send_text("not-json")
+        error = session.receive_json()
+
+    assert error["type"] == "error"
+    assert error["code"] == "invalid_json"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_ping_pong_round_trip(websocket_client: TestClient):
+    with websocket_client.websocket_connect("/ws/conversation/conv-3") as session:
+        session.receive_json()
+        session.receive_json()
+
+        session.send_json({"type": "ping"})
+        pong = session.receive_json()
+
+    assert pong["type"] == "pong"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_force_disconnect_and_reason(websocket_client: TestClient):
+    with websocket_client.websocket_connect("/ws/conversation/conv-4") as session:
+        session.receive_json()
+        session.receive_json()
+
+        session.send_json({"type": "disconnect", "reason": "test_case"})
+        disconnect_notice = session.receive_json()
+
+        assert disconnect_notice["type"] == "disconnect"
+        assert disconnect_notice["reason"] == "test_case"
+
+        with pytest.raises(WebSocketDisconnect):
+            session.receive_text()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reconnect_sends_status_update(websocket_client: TestClient):
+    # First connection
+    with websocket_client.websocket_connect("/ws/conversation/conv-5") as session:
+        session.receive_json()
+        session.receive_json()
+
+    # Reconnect should still provide connection + status
+    with websocket_client.websocket_connect("/ws/conversation/conv-5") as session:
+        reconnect_msg = session.receive_json()
+        status_msg = session.receive_json()
+
+    assert reconnect_msg["type"] == "connection"
+    assert status_msg["type"] == "status"
+    assert status_msg["connected_clients"] >= 1


### PR DESCRIPTION
## Summary
- add structured websocket error responses, disconnect reasons, and logging hooks
- implement heartbeat-based cleanup and reconnection status updates in websocket manager
- add async websocket tests and dummy dependency shims to cover connect, ping/pong, invalid JSON, disconnects, and reconnection flows

## Testing
- PYTHONPATH=backend python -m pytest backend/tests/test_websocket_manager.py backend/tests/test_websockets.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951efa0dd9c8324ab0d2e081ec0679a)