### PR TITLE
Enhance chat store persistence and tests

### DIFF
--- a/frontend/src/components/Chat/ChatStoreProvider.test.jsx
+++ b/frontend/src/components/Chat/ChatStoreProvider.test.jsx
@@ -1,0 +1,102 @@
+// src/components/Chat/ChatStoreProvider.test.jsx
+import React from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ChatStoreProvider, { useChatStore } from '../../store/ChatStore'
+import ConnectionStatus from '../ConnectionStatus'
+import ChatWindow from './ChatWindow'
+
+const conversationId = 'conversation-test'
+
+const StoreHarness = () => {
+  const { dispatch, state } = useChatStore()
+
+  return (
+    <div>
+      <ConnectionStatus />
+      <ChatWindow />
+      <div data-testid="last-error">{state.lastError || ''}</div>
+      <button
+        data-testid="connect"
+        onClick={() => dispatch({ type: 'CONNECTION_STATUS_CHANGED', payload: { status: 'Connected' } })}
+      >
+        Connect
+      </button>
+      <button
+        data-testid="disconnect"
+        onClick={() => dispatch({ type: 'CONNECTION_STATUS_CHANGED', payload: { status: 'Disconnected' } })}
+      >
+        Disconnect
+      </button>
+      <button
+        data-testid="add-message"
+        onClick={() => {
+          dispatch({ type: 'SET_ACTIVE_CONVERSATION', payload: { conversationId } })
+          dispatch({
+            type: 'MESSAGE_RECEIVED',
+            payload: {
+              conversationId,
+              message: {
+                id: 'm-1',
+                type: 'message',
+                sender_type: 'system',
+                content: 'Hello from the reducer',
+                timestamp: Date.now() / 1000
+              }
+            }
+          })
+        }}
+      >
+        Add message
+      </button>
+      <button
+        data-testid="trigger-error"
+        onClick={() => dispatch({ type: 'SET_ERROR', payload: { conversationId, error: 'WebSocket down' } })}
+      >
+        Trigger error
+      </button>
+    </div>
+  )
+}
+
+const renderHarness = () => render(
+  <ChatStoreProvider>
+    <StoreHarness />
+  </ChatStoreProvider>
+)
+
+describe('Chat store provider integration', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('updates connection status in the UI when dispatched', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+
+    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('connect'))
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('disconnect'))
+    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+  })
+
+  it('renders newly received messages for the active conversation', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+
+    await user.click(screen.getByTestId('add-message'))
+    expect(screen.getByText('Hello from the reducer')).toBeInTheDocument()
+  })
+
+  it('captures error states from the reducer', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+
+    await user.click(screen.getByTestId('trigger-error'))
+    expect(screen.getByTestId('last-error')).toHaveTextContent('WebSocket down')
+  })
+})

--- a/frontend/src/components/Chat/ChatWindow.jsx
+++ b/frontend/src/components/Chat/ChatWindow.jsx
@@ -7,11 +7,12 @@ import TypingIndicator from './TypingIndicator'
 const ChatWindow = () => {
   const { state } = useChatStore()
   const messagesEndRef = useRef(null)
+  const { activeConversationId, conversations } = state
 
   const messages = useMemo(() => {
-    if (!state.activeConversationId) return []
-    return selectMessages(state, state.activeConversationId)
-  }, [state])
+    if (!activeConversationId) return []
+    return selectMessages({ conversations }, activeConversationId)
+  }, [activeConversationId, conversations])
 
   const typingMessage = useMemo(
     () => messages.find(message => message.type === 'typing'),
@@ -19,7 +20,9 @@ const ChatWindow = () => {
   )
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    if (messagesEndRef.current?.scrollIntoView) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
   }, [messages])
 
   return (

--- a/frontend/src/components/Chat/TypingIndicator.jsx
+++ b/frontend/src/components/Chat/TypingIndicator.jsx
@@ -5,13 +5,14 @@ import PersonaAvatar from './PersonaAvatar'
 
 const TypingIndicator = ({ message: typingMessageOverride }) => {
   const { state } = useChatStore()
+  const { activeConversationId, conversations } = state
 
   const message = useMemo(() => {
     if (typingMessageOverride) return typingMessageOverride
-    if (!state.activeConversationId) return null
-    const messages = selectMessages(state, state.activeConversationId)
+    if (!activeConversationId) return null
+    const messages = selectMessages({ conversations }, activeConversationId)
     return messages.find(entry => entry.type === 'typing')
-  }, [state, typingMessageOverride])
+  }, [activeConversationId, conversations, typingMessageOverride])
 
   if (!message || message.type !== 'typing') {
     return null


### PR DESCRIPTION
## Summary
- trim chat store hydration/persistence with storage version safety and history limits
- refactor chat components to consume store selectors and guard scrolling in jsdom
- add RTL component tests covering connection, message, and error reducer flows

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a70f663883249b01983cf5225f82)