### PR TITLE
Add initial Alembic migration and db upgrade workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,8 @@ down:
 
 # Database commands
 db-upgrade:
+        cd backend && python -m venv venv || true
+        cd backend && . venv/bin/activate && pip install -r requirements.txt
         cd backend && . venv/bin/activate && alembic -c alembic.ini upgrade head
 
 migrate:

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,8 @@
 # Backend setup and migrations
 
-This backend uses Alembic to manage the SQLAlchemy models. To align a local database with the current `User`, `Conversation`, and `Message` schemas:
+The backend uses Alembic to manage the SQLAlchemy models for `User`, `Conversation`, and `Message`. The first revision lives at `backend/alembic/versions/0001_initial_models.py` and captures the current schema.
 
+## Prepare a local environment
 1. Create and activate a virtual environment inside `backend/`:
    ```bash
    cd backend
@@ -9,18 +10,27 @@ This backend uses Alembic to manage the SQLAlchemy models. To align a local data
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Point `DATABASE_URL` to your target database (defaults to `sqlite:///./chimera.db`).
-3. Apply migrations with the repo-level helper:
-   ```bash
-   make db-upgrade
-   ```
-   The target runs `alembic -c alembic.ini upgrade head` against the configured database.
+2. Point the database URL to your target database (defaults to `sqlite:///./chimera.db`). You can set `DATABASE_URL` in the environment or edit `alembic.ini`.
 
-For manual runs, you can also execute Alembic directly:
+## Apply migrations
+Use the repo-level helper to run Alembic with the bundled `alembic.ini`:
+```bash
+make db-upgrade
+```
+This target executes `alembic -c alembic.ini upgrade head` from the `backend/` directory so contributors can sync schema with a single command.
+
+You can also run Alembic directly if you prefer manual control:
 ```bash
 cd backend
 source venv/bin/activate
 alembic -c alembic.ini upgrade head
 ```
 
-After running migrations, the database will include the latest columns for authentication, conversation sharing, and message metadata alignment. A lightweight smoke test is available via `python -m pytest tests/test_db_connectivity.py` to verify connectivity.
+## Smoke-test connectivity
+After applying migrations, verify that SQLAlchemy can create, read, update, and delete records by running the lightweight smoke test:
+```bash
+cd backend
+source venv/bin/activate
+python -m pytest tests/test_db_connectivity.py -q
+```
+This test spins up a temporary in-memory database with `SessionLocal` and performs a CRUD round trip against the `User` model.

--- a/backend/alembic/versions/0001_initial_models.py
+++ b/backend/alembic/versions/0001_initial_models.py
@@ -1,0 +1,123 @@
+# backend/alembic/versions/0001_initial_models.py
+"""Create initial users, conversations, and messages tables.
+
+Revision ID: 0001_initial_models
+Revises: None
+Create Date: 2024-10-12
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_initial_models"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create core tables for users, conversations, and messages."""
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("username", sa.String(length=100), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("hashed_password", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_users_username", "users", ["username"], unique=True)
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "conversations",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=True),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column(
+            "ai_participants",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column(
+            "active_personas",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "conversation_mode",
+            sa.String(length=50),
+            nullable=True,
+            server_default=sa.text("'sequential'"),
+        ),
+        sa.Column("is_public", sa.Boolean(), nullable=True, server_default=sa.text("0")),
+        sa.Column("share_token", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_conversations_user_id", "conversations", ["user_id"], unique=False
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("conversation_id", sa.String(length=36), nullable=True),
+        sa.Column("sender_type", sa.String(length=20), nullable=False),
+        sa.Column("sender_id", sa.String(length=100), nullable=True),
+        sa.Column("persona", sa.String(length=50), nullable=True),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "metadata",
+            sa.JSON(),
+            nullable=True,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column("message_order", sa.BigInteger(), autoincrement=True, nullable=True),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_messages_conversation_id", "messages", ["conversation_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Drop core tables if a migration rollback is requested."""
+    op.drop_index("ix_messages_conversation_id", table_name="messages")
+    op.drop_table("messages")
+
+    op.drop_index("ix_conversations_user_id", table_name="conversations")
+    op.drop_table("conversations")
+
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_table("users")


### PR DESCRIPTION
## Summary
- add the first Alembic revision to create the users, conversations, and messages tables
- update the db-upgrade Makefile target to bootstrap a venv, install dependencies, and run `alembic -c alembic.ini upgrade head`
- document backend migration steps and the connectivity smoke test

## Testing
- python -m pytest tests/test_db_connectivity.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a70a938483249b6f8c334ca10e3f)